### PR TITLE
Type aliases dev

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,7 @@
  ∙ Functionality for arrays of any length - repeated constraints
  ∙ Type aliases, for example: Vector -> {x: Number, y: Number}
  ∙ Constraints in classes: constructors, getters, setters, and methods
+ ∙ Don't break when no default value is given
+ ∙ Functionality to type function arguments. Type for the arguments and arguments
+   ∙ e.g. 'function (f=((x=Number, y=Number) => { x * y }))', when typed, would take
+     a function fitting the definition

--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
  ∙ Functionality for arrays of any length - repeated constraints
- ∙ Type aliases, for example: Vector -> {x: Number, y: Number}
  ∙ Constraints in classes: constructors, getters, setters, and methods
  ∙ Don't break when no default value is given
  ∙ Functionality to type function arguments. Type for the arguments and arguments

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const esprima = require('esprima')
 const mapValues = require('object.map')
 

--- a/index.js
+++ b/index.js
@@ -203,11 +203,3 @@ exports.typedef = function (fn) {
 }
 
 exports.getDefinedAliases = () => { return aliases }
-
-/*
-exports.typedef((x=Number, y=Number) => Vector)
-
-let mul = exports.type((a=Vector, b=Number) => { return { x: a.x * b, y: a.y * b } })
-
-mul({x: 5, y: 3}, 2)
-*/

--- a/index.js
+++ b/index.js
@@ -191,5 +191,3 @@ exports.typedef = function (fn) {
 }
 
 exports.getDefinedAliases = () => { return aliases }
-
-// exports.typedef((x=Number, y=Number) => { Vector })

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function getType (expr) {
 
     for (let alias of aliases) {
       if (alias.name === name) {
-        return alias
+        return expandAlias(alias)
       }
     }
 
@@ -98,6 +98,18 @@ function getType (expr) {
   } else {
     err('Type', `Invalid constraint '${typeToString(type)}'. Expected a Function, Array, or Object`)
   }
+}
+
+function expandAlias (type) {
+  const obj = {}
+
+  for (var prop in type.type) {
+    if (type.type.hasOwnProperty(prop)) {
+      obj[prop] = type.type[prop]
+    }
+  }
+
+  return obj
 }
 
 function checkArguments (types, args) {
@@ -171,12 +183,12 @@ exports.typeAll = function (object) {
 exports.typedef = function (fn) {
   const exp = esprima.parse(`(${fn.toString()})`).body[0].expression
 
-  if (exp.body.body.length !== 1) {
-    throw new Error('Expecting exactly one identifier to define an alias as!')
+  if (exp.body.type !== 'Identifier') {
+    throw new Error('Expecting an identifier for the alias')
   }
 
   const alias = {
-    name: exp.body.body[0].expression.name,
+    name: exp.body.name,
     type: {}
   }
 
@@ -191,3 +203,11 @@ exports.typedef = function (fn) {
 }
 
 exports.getDefinedAliases = () => { return aliases }
+
+/*
+exports.typedef((x=Number, y=Number) => Vector)
+
+let mul = exports.type((a=Vector, b=Number) => { return { x: a.x * b, y: a.y * b } })
+
+mul({x: 5, y: 3}, 2)
+*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argtyper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "JS type-checker - no compilation!",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,8 @@ var expect = chai.expect
 var argtyper = require('../index')
 
 var type = argtyper.type,
-  typeAll = argtyper.typeAll
+  typeAll = argtyper.typeAll,
+  typedef = argtyper.typedef
 
 // Define a test function
 function add(a=Number, b=Number) {
@@ -14,127 +15,156 @@ function add(a=Number, b=Number) {
 add = type(add)
 
 describe('argtyper', function() {
-  describe('type()', function() {
-    it('should allow correctly typed arguments', () => {
-      expect(() => {
-        add(5, 5)
-      }).to.not.throw(Error).and.to.equal(10)
+  it('should allow correctly typed arguments', () => {
+    expect(() => {
+      add(5, 5)
+    }).to.not.throw(Error).and.to.equal(10)
 
-      expect(() => {
-        add(5, true)
-      }).to.throw(Error)
-    })
-
-    it('should disallow too few arguments', () => {
-      expect(() => {
-        add(5)
-      }).to.throw(Error)
-    })
-
-    it('should disallow too many arguments', () => {
-      expect(() => {
-        add(1, 2, 3)
-      }).to.throw(Error)
-    })
-
-    it('should work with the \'Any\' class to allow polymorphic constraints', () => {
-      const fn = type(function(a=Any(Number, String)) {})
-
-      expect(() => {
-        fn(5)
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn('hello')
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn(true)
-      }).to.throw(Error)
-    })
-
-    it('should work with the \'Any\' class to allow untyped arguments', () => {
-      const fn = type(function(a=Any, b=String) {})
-
-      expect(() => {
-        fn(true, 'hello')
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn(5, 'hello')
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn(() => {}, 'hello')
-      }).to.not.throw(Error)
-    })
-
-    it('should work with n-dimensional arrays', () => {
-      const fn = type(function(a=[Number, [Number, [Number, [Number]]]]) {})
-
-      expect(() => {
-        fn([1, [2, [3, [4]]]])
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn([1, [2, [3, [true]]]])
-      }).to.throw(Error)
-    })
-
-    it('should work with n-dimensional objects', () => {
-      const fn = type(function(a={x: {y: {z: Number}}}) {})
-
-      expect(() => {
-        fn({x: {y: {z: 5}}})
-      }).to.not.throw(Error)
-
-      expect(() => {
-        fn({x: {y: {z: true}}})
-      }).to.throw(Error)
-    })
+    expect(() => {
+      add(5, true)
+    }).to.throw(Error)
   })
 
-  describe('typeAll()', () => {
-    it('should work when an object only contains functions', () => {
-      const obj = {
-        add: function(x=Number, y=Number) {
-          return x + y
-        },
-        mul: function(x=Number, y=Number) {
-          return x * y
-        }
-      }
+  it('should disallow too few arguments', () => {
+    expect(() => {
+      add(5)
+    }).to.throw(Error)
+  })
 
-      expect(function() {
-        typeAll(obj)
-      }).to.not.throw(Error)
+  it('should disallow too many arguments', () => {
+    expect(() => {
+      add(1, 2, 3)
+    }).to.throw(Error)
+  })
 
-      expect(obj.add(3, 5)).to.equal(8)
-      expect(obj.mul(2, 10)).to.equal(20)
+  it('should work with the \'Any\' class to allow polymorphic constraints', () => {
+    const fn = type(function(a=Any(Number, String)) {})
 
-      expect(function() {
-        obj.add('a', 1)
-      }).to.throw(Error)
+    expect(() => {
+      fn(5)
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn('hello')
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn(true)
+    }).to.throw(Error)
+  })
+
+  it('should work with the \'Any\' class to allow untyped arguments', () => {
+    const fn = type(function(a=Any, b=String) {})
+
+    expect(() => {
+      fn(true, 'hello')
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn(5, 'hello')
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn(() => {}, 'hello')
+    }).to.not.throw(Error)
+  })
+
+  it('should work with n-dimensional arrays', () => {
+    const fn = type(function(a=[Number, [Number, [Number, [Number]]]]) {})
+
+    expect(() => {
+      fn([1, [2, [3, [4]]]])
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn([1, [2, [3, [true]]]])
+    }).to.throw(Error)
+  })
+
+  it('should work with n-dimensional objects', () => {
+    const fn = type(function(a={x: {y: {z: Number}}}) {})
+
+    expect(() => {
+      fn({x: {y: {z: 5}}})
+    }).to.not.throw(Error)
+
+    expect(() => {
+      fn({x: {y: {z: true}}})
+    }).to.throw(Error)
+  })
+
+  it('should work with aliases', () => {
+    typedef((x=Number, y=Number) => Vector)
+
+    const mul = type((a=Vector, b=Number) => {
+      return { x: a.x * b, y: a.y * b }
     })
 
-    it('should work on a mix of functions and other values', () => {
-      const obj = {
-        add: function(x=Number, y=Number) {
-          return x + y
-        },
-        j: 10,
-        k: {}
-      }
+    expect(() => {
+      return mul({x: 5, y: 3}, 2)
+    }).to.not.throw(Error).and.to.equal({ x: 10, y: 6 })
 
-      expect(function() {
-        typeAll(obj)
-      }).to.not.throw(Error)
+    expect(() => {
+      return mul({x: 3, y: ';-)'}, 3)
+    }).to.throw(Error)
+  })
 
-      expect(obj.add(3, 5)).to.equal(8)
+  it('aliases should work inside other aliases', () => {
+    typedef((x=Number, y=Number) => Vector)
+    typedef((a=Vector, b=Vector) => TwoVectors)
 
-      expect(function() {
-        obj.add('a', 1)
-      }).to.throw(Error)
+    const add = type((x=TwoVectors) => {
+      return { x: x.a.x + x.b.x, y: x.a.y + x.b.y }
     })
+
+    expect(() => {
+      return add({a: {x: 1, y: 2}, b: {x: 3, y: 4}})
+    }).to.not.throw(Error).and.to.equal({ x: 4, y: 6 })
+
+    expect(() => {
+      return add({a: 's', b: {x: 3, y: 4}})
+    }).to.throw(Error)
+  })
+
+  it('typeAll should work on an object only containing functions', () => {
+    const obj = {
+      add: function(x=Number, y=Number) {
+        return x + y
+      },
+      mul: function(x=Number, y=Number) {
+        return x * y
+      }
+    }
+
+    expect(function() {
+      typeAll(obj)
+    }).to.not.throw(Error)
+
+    expect(obj.add(3, 5)).to.equal(8)
+    expect(obj.mul(2, 10)).to.equal(20)
+
+    expect(function() {
+      obj.add('a', 1)
+    }).to.throw(Error)
+  })
+
+  it('typeAll should work on a mix of functions and other values', () => {
+    const obj = {
+      add: function(x=Number, y=Number) {
+        return x + y
+      },
+      j: 10,
+      k: {}
+    }
+
+    expect(function() {
+      typeAll(obj)
+    }).to.not.throw(Error)
+
+    expect(obj.add(3, 5)).to.equal(8)
+
+    expect(function() {
+      obj.add('a', 1)
+    }).to.throw(Error)
   })
 })


### PR DESCRIPTION
Implement type aliases, for example defining an alias called Vector, which is then transformed into an object containing an x and a y component. The Vector alias could then be used identically to that object, when defining constraints.