### PR TITLE
Install mocha from devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/Zac-Garby/argtyper#readme",
   "devDependencies": {
     "chai": "*",
+    "mocha": "^4.0.1",
     "standard": "^10.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Don't rely on a developer having Mocha installed globally.