### PR TITLE
Make some simple performance improvements

### DIFF
--- a/js/errors.js
+++ b/js/errors.js
@@ -1,6 +1,6 @@
 exports.error = function (type, text, stacktrace = null) {
   if (stacktrace) {
-    let str = `(${type}) ${text}`
+    var str = `(${type}) ${text}`
     for (const item of stacktrace.reverse()) {
       str += `\n    of ${item}`
     }

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -18,7 +18,7 @@ exports.wrapType = function (constructor) {
   if (constructor.constructor === Array) {
     return new ArrayType(...constructor.map(exports.wrapType))
   } else if (constructor.constructor === Object) {
-    let obj = {}
+    var obj = {}
 
     for (var prop in constructor) {
       if (constructor.hasOwnProperty(prop)) {
@@ -43,7 +43,7 @@ exports.wrapValue = function (val) {
   if (constructor === Array) {
     return new ArrayType(...val.map(exports.wrapValue))
   } else if (constructor === Object) {
-    let obj = {}
+    var obj = {}
 
     for (var prop in val) {
       if (val.hasOwnProperty(prop)) {
@@ -65,7 +65,7 @@ exports.getType = function (AST, aliases) {
 
   switch (type) {
     case 'Identifier':
-      for (let alias of aliases) {
+      for (var alias of aliases) {
         if (alias.name === AST.name) {
           return exports.getType(alias.AST, aliases)
         }
@@ -91,7 +91,7 @@ exports.getType = function (AST, aliases) {
           const amount = right.value
           const arr = []
 
-          for (let i = 0; i < amount; i++) {
+          for (var i = 0; i < amount; i++) {
             arr.push(constraint)
           }
 

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -102,13 +102,13 @@ exports.getType = function (AST, aliases) {
         }
       }
 
-      let arr = elems.map((elem) => exports.getType(elem, aliases))
+      const arr = elems.map((elem) => exports.getType(elem, aliases))
 
       return new ArrayType(...arr)
     case 'ObjectExpression':
-      let obj = {}
+      const obj = {}
 
-      for (let prop of AST.properties) {
+      for (var prop of AST.properties) {
         assert(prop.key.type === 'Identifier', 'Parse', 'Expected an identifier for every key')
 
         obj[prop.key.name] = exports.getType(prop.value, aliases)

--- a/js/index.js
+++ b/js/index.js
@@ -15,15 +15,12 @@ function checkArguments (types, argumentsObject) {
   var args = []
   var i
 
-  for (i = 0; i < argumentsObject.length; i++) {
-    args[i] = wrapValue(argumentsObject[i])
-  }
+  assert(types.length >= argumentsObject.length, 'Type', `${argumentsObject.length - types.length} too many arguments!`)
 
   for (i = 0; i < types.length; i++) {
-    args = types[i].check(args, [`argument ${i + 1}`])
+    args[i] = wrapValue(argumentsObject[i])
+    types[i].check([args[i]], [`argument ${i + 1}`])
   }
-
-  assert(args.length === 0, 'Type', `${args.length} too many arguments!`)
 }
 
 exports.type = function (fn) {

--- a/js/index.js
+++ b/js/index.js
@@ -12,14 +12,12 @@ const getType = require('./helpers').getType
 const aliases = []
 
 function checkArguments (types, argumentsObject) {
-  var args = []
   var i
 
   assert(types.length >= argumentsObject.length, 'Type', `${argumentsObject.length - types.length} too many arguments!`)
 
   for (i = 0; i < types.length; i++) {
-    args[i] = wrapValue(argumentsObject[i])
-    types[i].check([args[i]], [`argument ${i + 1}`])
+    types[i].check(wrapValue(argumentsObject[i]), [`argument ${i + 1}`])
   }
 }
 
@@ -54,7 +52,7 @@ exports.type = function (fn) {
 
     if (returnType) {
       let applied = result()
-      returnType.check([wrapValue(applied)], [])
+      returnType.check(wrapValue(applied), [])
 
       return applied
     }

--- a/js/index.js
+++ b/js/index.js
@@ -12,11 +12,9 @@ const getType = require('./helpers').getType
 const aliases = []
 
 function checkArguments (types, argumentsObject) {
-  var i
-
   assert(types.length >= argumentsObject.length, 'Type', `${argumentsObject.length - types.length} too many arguments!`)
 
-  for (i = 0; i < types.length; i++) {
+  for (var i = 0, len = types.length; i < len; i++) {
     types[i].check(wrapValue(argumentsObject[i]), [`argument ${i + 1}`])
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -21,11 +21,11 @@ function checkArguments (types, argumentsObject) {
 
 exports.type = function (fn) {
   const exp = esprima.parse(`(${fn.toString()})`).body[0].expression
-  let returnType = null
+  var returnType = null
 
   if (exp.body.type === 'ArrowFunctionExpression' &&
       exp.body.params.length === 1) {
-    let params = exp.body.params
+    const params = exp.body.params
 
     if (params[0].type === 'AssignmentPattern') {
       assert(params[0].left.name === '_', 'Parse', `Unexpected param name: '${params[0].left.name}'. Expected '_'`)
@@ -49,7 +49,7 @@ exports.type = function (fn) {
     const result = fn.apply(undefined, arguments)
 
     if (returnType) {
-      let applied = result()
+      const applied = result()
       returnType.check(wrapValue(applied), [])
 
       return applied

--- a/js/index.js
+++ b/js/index.js
@@ -12,13 +12,15 @@ const getType = require('./helpers').getType
 const aliases = []
 
 function checkArguments (types, argumentsObject) {
-  let args = []
-  for (let i = 0; i < argumentsObject.length; i++) {
+  var args = []
+  var i
+
+  for (i = 0; i < argumentsObject.length; i++) {
     args[i] = wrapValue(argumentsObject[i])
   }
 
-  for (let t = 0; t < types.length; t++) {
-    args = types[t].check(args, [`argument ${t + 1}`])
+  for (i = 0; i < types.length; i++) {
+    args = types[i].check(args, [`argument ${i + 1}`])
   }
 
   assert(args.length === 0, 'Type', `${args.length} too many arguments!`)

--- a/js/types/AnyType.js
+++ b/js/types/AnyType.js
@@ -8,6 +8,5 @@ exports.AnyType = class AnyType {
   }
 
   check (args, stacktrace) {
-    return args.slice(1)
   }
 }

--- a/js/types/AnyType.js
+++ b/js/types/AnyType.js
@@ -7,6 +7,6 @@ exports.AnyType = class AnyType {
     return 'Any'
   }
 
-  check (args, stacktrace) {
+  check (arg, stacktrace) {
   }
 }

--- a/js/types/ArrayType.js
+++ b/js/types/ArrayType.js
@@ -12,20 +12,17 @@ exports.ArrayType = class ArrayType {
     }, '[') + ']'
   }
 
-  check (args, stacktrace) {
-    assert(args.length > 0, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
+  check (arg, stacktrace) {
+    assert(!!arg, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
 
-    const that = args[0]
+    assert(arg.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${arg.name}`, stacktrace)
 
-    assert(that.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${that.name}`, stacktrace)
-
-    let elems = that.elements
+    let elems = arg.elements
     let types = this.elements
     assert(types.length >= elems.length, 'Type', `${elems.length - types.length} too many value(s)`, stacktrace)
 
     for (let t = 0; t < types.length; t++) {
-      const type = types[t]
-      type.check([elems[t]], [...stacktrace, `element ${t + 1}`])
+      types[t].check(elems[t], [...stacktrace, `element ${t + 1}`])
     }
   }
 }

--- a/js/types/ArrayType.js
+++ b/js/types/ArrayType.js
@@ -21,14 +21,11 @@ exports.ArrayType = class ArrayType {
 
     let elems = that.elements
     let types = this.elements
+    assert(types.length >= elems.length, 'Type', `${elems.length - types.length} too many value(s)`, stacktrace)
 
     for (let t = 0; t < types.length; t++) {
       const type = types[t]
-      elems = type.check(elems, [...stacktrace, `element ${t + 1}`])
+      type.check([elems[t]], [...stacktrace, `element ${t + 1}`])
     }
-
-    assert(elems.length === 0, 'Type', `${elems.length} too many value(s)`, stacktrace)
-
-    return args.slice(1)
   }
 }

--- a/js/types/ArrayType.js
+++ b/js/types/ArrayType.js
@@ -17,8 +17,8 @@ exports.ArrayType = class ArrayType {
 
     assert(arg.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${arg.name}`, stacktrace)
 
-    let elems = arg.elements
-    let types = this.elements
+    const elems = arg.elements
+    const types = this.elements
     assert(types.length >= elems.length, 'Type', `${elems.length - types.length} too many value(s)`, stacktrace)
 
     for (var i = 0, len = types.length; i < len; i++) {

--- a/js/types/ArrayType.js
+++ b/js/types/ArrayType.js
@@ -21,8 +21,8 @@ exports.ArrayType = class ArrayType {
     let types = this.elements
     assert(types.length >= elems.length, 'Type', `${elems.length - types.length} too many value(s)`, stacktrace)
 
-    for (let t = 0; t < types.length; t++) {
-      types[t].check(elems[t], [...stacktrace, `element ${t + 1}`])
+    for (var i = 0, len = types.length; i < len; i++) {
+      types[i].check(elems[i], [...stacktrace, `element ${i + 1}`])
     }
   }
 }

--- a/js/types/LiteralType.js
+++ b/js/types/LiteralType.js
@@ -17,7 +17,5 @@ exports.LiteralType = class LiteralType {
 
     assert(that.constructor === LiteralType, 'Type', `Wrong type. Expected a basic type, but found ${that.name}`, stacktrace)
       .and(that.type === this.type, 'Type', `Wrong type. Expected ${this} but found ${that}`, stacktrace)
-
-    return args.slice(1)
   }
 }

--- a/js/types/LiteralType.js
+++ b/js/types/LiteralType.js
@@ -10,12 +10,10 @@ exports.LiteralType = class LiteralType {
     return this.type.name
   }
 
-  check (args, stacktrace) {
-    assert(args.length > 0, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
+  check (arg, stacktrace) {
+    assert(!!arg, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
 
-    const that = args[0]
-
-    assert(that.constructor === LiteralType, 'Type', `Wrong type. Expected a basic type, but found ${that.name}`, stacktrace)
-      .and(that.type === this.type, 'Type', `Wrong type. Expected ${this} but found ${that}`, stacktrace)
+    assert(arg.constructor === LiteralType, 'Type', `Wrong type. Expected a basic type, but found ${arg.name}`, stacktrace)
+      .and(arg.type === this.type, 'Type', `Wrong type. Expected ${this} but found ${arg}`, stacktrace)
   }
 }

--- a/js/types/ObjectType.js
+++ b/js/types/ObjectType.js
@@ -30,7 +30,5 @@ exports.ObjectType = class ObjectType {
         this.model[prop].check([that.model[prop]], stacktrace)
       }
     }
-
-    return args.slice(1)
   }
 }

--- a/js/types/ObjectType.js
+++ b/js/types/ObjectType.js
@@ -10,24 +10,22 @@ exports.ObjectType = class ObjectType {
     return JSON.stringify(this.model)
   }
 
-  check (args, stacktrace) {
-    assert(args.length > 0, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
+  check (arg, stacktrace) {
+    assert(!!arg, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
 
-    const that = args[0]
-
-    assert(that.constructor === ObjectType, 'Type', `Wrong type. Expected an object, but found ${that.name}`, stacktrace)
+    assert(arg.constructor === ObjectType, 'Type', `Wrong type. Expected an object, but found ${arg.name}`, stacktrace)
 
     const thisLength = Object.keys(this.model).length
-    const thatLength = Object.keys(that.model).length
+    const argLength = Object.keys(arg.model).length
 
-    assert(thisLength === thatLength, 'Type', `Expected ${thisLength} properties, but found ${thatLength}`, stacktrace)
+    assert(thisLength === argLength, 'Type', `Expected ${thisLength} properties, but found ${argLength}`, stacktrace)
 
     for (var prop in this.model) {
       if (this.model.hasOwnProperty(prop)) {
-        assert(that.model.hasOwnProperty(prop), 'Type', `Expected property ${prop} to be defined`,
+        assert(arg.model.hasOwnProperty(prop), 'Type', `Expected property ${prop} to be defined`,
           [...stacktrace, `property ${prop}`])
 
-        this.model[prop].check([that.model[prop]], stacktrace)
+        this.model[prop].check(arg.model[prop], stacktrace)
       }
     }
   }

--- a/js/types/PolymorphicType.js
+++ b/js/types/PolymorphicType.js
@@ -27,7 +27,5 @@ exports.PolymorphicType = class PolymorphicType {
     })
 
     assert(match, 'Type', `Wrong type. Expected ${this} but found ${that}`, stacktrace)
-
-    return args.slice(1)
   }
 }

--- a/js/types/PolymorphicType.js
+++ b/js/types/PolymorphicType.js
@@ -12,20 +12,18 @@ exports.PolymorphicType = class PolymorphicType {
     }, '<') + '>'
   }
 
-  check (args, stacktrace) {
-    assert(args.length > 0, 'Type', `Expected at least one more argument to match ${this}`, stacktrace)
-
-    const that = args[0]
+  check (arg, stacktrace) {
+    assert(!!arg, 'Type', `Expected at least one more argument to match ${this}`, stacktrace)
 
     const match = this.types.some((type) => {
       try {
-        type.check([that])
+        type.check(arg)
         return true
       } catch (e) {
         return false
       }
     })
 
-    assert(match, 'Type', `Wrong type. Expected ${this} but found ${that}`, stacktrace)
+    assert(match, 'Type', `Wrong type. Expected ${this} but found ${arg}`, stacktrace)
   }
 }

--- a/js/types/RepeatedType.js
+++ b/js/types/RepeatedType.js
@@ -12,18 +12,16 @@ exports.RepeatedType = class RepeatedType {
     return `[...${this.type}]`
   }
 
-  check (args, stacktrace) {
-    assert(args.length > 0, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
+  check (arg, stacktrace) {
+    assert(!!arg, 'Type', `Expected at least one more value to match ${this}`, stacktrace)
 
-    const that = args[0]
+    assert(arg.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${arg.name}`, stacktrace)
+      .and(arg.elements.length > 0, 'Type', 'Expected at least one element in the array', stacktrace)
 
-    assert(that.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${that.name}`, stacktrace)
-      .and(that.elements.length > 0, 'Type', 'Expected at least one element in the array', stacktrace)
-
-    for (let i = 0; i < that.elements.length; i++) {
-      let elem = that.elements[i]
+    for (let i = 0; i < arg.elements.length; i++) {
+      let elem = arg.elements[i]
       try {
-        this.type.check([elem])
+        this.type.check(elem)
       } catch (e) {
         return assert(false, 'Type', `Wrong type. Expected ${this.type}, but found ${elem}`,
           [...stacktrace, `element ${i + 1}`])

--- a/js/types/RepeatedType.js
+++ b/js/types/RepeatedType.js
@@ -18,7 +18,7 @@ exports.RepeatedType = class RepeatedType {
     assert(arg.constructor === ArrayType, 'Type', `Wrong type. Expected an array, but found ${arg.name}`, stacktrace)
       .and(arg.elements.length > 0, 'Type', 'Expected at least one element in the array', stacktrace)
 
-    for (let i = 0; i < arg.elements.length; i++) {
+    for (var i = 0, len = arg.elements.length; i < len; i++) {
       let elem = arg.elements[i]
       try {
         this.type.check(elem)

--- a/js/types/RepeatedType.js
+++ b/js/types/RepeatedType.js
@@ -29,7 +29,5 @@ exports.RepeatedType = class RepeatedType {
           [...stacktrace, `element ${i + 1}`])
       }
     }
-
-    return args.slice(1)
   }
 }

--- a/js/types/RepeatedType.js
+++ b/js/types/RepeatedType.js
@@ -19,7 +19,7 @@ exports.RepeatedType = class RepeatedType {
       .and(arg.elements.length > 0, 'Type', 'Expected at least one element in the array', stacktrace)
 
     for (var i = 0, len = arg.elements.length; i < len; i++) {
-      let elem = arg.elements[i]
+      const elem = arg.elements[i]
       try {
         this.type.check(elem)
       } catch (e) {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,33 @@
+const argtyper = require('../js/index')
+const perf = require('perf_hooks').performance
+
+const type = argtyper.type
+
+function add(a = Number, b = Number) {
+  return a + b
+}
+const addWithTypes = type(add)
+const REPETITIONS = 100000
+
+var i = 0
+
+perf.mark('start without types')
+for (i = 0; i < REPETITIONS; i++) {
+  add(i, i+1)
+}
+perf.mark('stop without types')
+
+perf.mark('start with types')
+for (i = 0; i < REPETITIONS; i++) {
+  addWithTypes(i, i+1)
+}
+perf.mark('stop with types')
+perf.measure('without types', 'start without types', 'stop without types')
+perf.measure('with types', 'start with types', 'stop with types')
+
+const measureWithoutTypes = perf.getEntriesByName('without types')[0]
+const measureWithTypes = perf.getEntriesByName('with types')[0]
+
+console.log('without types', measureWithoutTypes.duration)
+console.log('with types', measureWithTypes.duration)
+console.log(`with types is ${measureWithTypes.duration / measureWithoutTypes.duration} times slower`)


### PR DESCRIPTION
I did a few simple things to speed up a function wrapped by `type`, but there's a lot more that could be done with a fundamental overhaul.

- let is slower than var
- caching the `length` array property in a for loop
- combine extraneous loops
- avoid creating unnecessary arrays

The script I wrote to benchmark is included. I saw a drop from about 40x slower with 100,000 iterations to about 25x slower.

The main problem is all the wrapping. There is lots of stuff in here that v8 can't optimize. Fixing that stuff would require rearchitecting the package.

Addresses a portion of #6. Edit this line to "Fixes" if you want #6 closed without a large rewrite.